### PR TITLE
Improved style of calendar menu

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -116,7 +116,8 @@ const PersianCalendar = new Lang.Class({
 
         let vbox = new St.BoxLayout({vertical: true});
         let calendar = new PopupMenu.PopupBaseMenuItem({
-            reactive: false,
+            activate: false,
+            hover: false,
             can_focus: false
         });
         calendar.actor.add_child(vbox);


### PR DESCRIPTION
سلام . من متوجه شدم متن مناسبت ها و برخی از اجزای منوی تقویم کمرنگ هستن. بررسی کردم به دلیل استفاده از `reactive: false` بود که باعث میشد کل منو در حالت غیر فعال  باشه . این بخش از کد رو به `activate: false, hover: false` تغییر دادم که دقیقا چیزی که مورد نظره رو انجام میده یعنی کلیک شدن کل منو و `hover` شدن اون به وسیله ی موس رو غیر فعال میکنه و بقیه ی موارد رو بی تغییر به جا میذاره.
فکر میکنم اینطور منو بهتر دیده میشه . در صورتی که مشکلی از نظر شما وجود نداشت ادغام کنید . ممنون