### PR TITLE
Fix preferences button on GS 3.36.2

### DIFF
--- a/PersianCalendar@oxygenws.com/extension.js
+++ b/PersianCalendar@oxygenws.com/extension.js
@@ -163,7 +163,15 @@ const PersianCalendar = new Lang.Class({
             can_focus: true,
         });
         preferencesIcon.connect('clicked', function () {
-            Util.spawn(['gnome-extensions prefs', extension.metadata.uuid]);
+            if (typeof ExtensionUtils.openPrefs === 'function') {
+                ExtensionUtils.openPrefs();
+            } else {
+                // support previous gnome shell versions.
+                Util.spawn([
+                    "gnome-shell-extension-prefs",
+                    extension.metadata.uuid
+                ]);
+            }
         });
         actionButtons.actor.add(preferencesIcon, {expand: true, x_fill: false});
 


### PR DESCRIPTION
Fixes the issue of broken preferences button by using the new openPrefs() convenience method [introduced on GS 3.36.2 ](https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/1163), while maintaining compatibility with the previous GS versions. 