### PR TITLE
Recover support old gnome versions from 3.14

### DIFF
--- a/PersianCalendar@oxygenws.com/extension.js
+++ b/PersianCalendar@oxygenws.com/extension.js
@@ -47,7 +47,7 @@ const PersianCalendar = new Lang.Class({
             y_expand: true,
             y_align: Clutter.ActorAlign.CENTER,
         });
-        this.add_actor(this.label);
+        this.actor.add_actor(this.label);
 
         // some codes for coloring label
         if (Schema.get_boolean('custom-color')) {

--- a/PersianCalendar@oxygenws.com/metadata.json
+++ b/PersianCalendar@oxygenws.com/metadata.json
@@ -4,9 +4,20 @@
   "name": "Persian Calendar",
   "original-authors": "Omid Mottaghi Rad",
   "shell-version": [
+    "3.14",
+    "3.16",
+    "3.18",
+    "3.20",
+    "3.22",
+    "3.24",
+    "3.26",
+    "3.28",
+    "3.30",
+    "3.32",
+    "3.34",
     "3.36"
   ],
   "url": "https://github.com/omid/Persian-Calendar-for-Gnome-Shell",
   "uuid": "PersianCalendar@oxygenws.com",
-  "version": 70
+  "version": 71
 }


### PR DESCRIPTION
با همین تغییر کوچک، مشکل برای نسخه‌های قدیمی‌تر گنوم برطرف گردیده و در نسخه‌های زیر نیز با موفّقیت تست شد:
debian - Gnome 3.14
debian - Gnome 3.30
ubuntu - Gnome 3.36
شاید برای نسخه‌های قدیمی‌تر از 3.14 نیز سازگار باشد، امّا تست نشده است و احتمالاً نیاز نمی‌شود...