### PR TITLE
بهبود الگوریتم‌های قمری و شمسی و پشتیبانی از گنوم 3.20

### DIFF
--- a/PersianCalendar@oxygenws.com/HijriDate.js
+++ b/PersianCalendar@oxygenws.com/HijriDate.js
@@ -1,71 +1,134 @@
 /*
- * Based on a code from http://www.tabibmuda.com/page.php?8
+ * Temp Codes By https://jdf.scr.ir (v0.1.0 ,GNU/LGPL)
  */
 
 var HijriDate = {};
 
-HijriDate.intPart = function (floatNum) {
-    if (floatNum < -0.0000001) {
-        return Math.ceil(floatNum - 0.0000001);
-    }
-    return Math.floor(floatNum + 0.0000001);
-};
-
 HijriDate.toHijri = function (y, m, d) {
-    y = parseInt(y);
-    m = parseInt(m);
-    d = parseInt(d);
-
-    let j, jd, l, n;
-    if ((y > 1582) || ((y === 1582) && (m > 10)) || ((y === 1582) && (m === 10) && (d > 14))) {
-        jd = HijriDate.intPart((1461 * (y + 4800 + HijriDate.intPart((m - 14) / 12))) / 4) +
-            HijriDate.intPart((367 * (m - 2 - 12 * (HijriDate.intPart((m - 14) / 12)))) / 12) -
-            HijriDate.intPart((3 * (HijriDate.intPart((y + 4900 + HijriDate.intPart((m - 14) / 12)) / 100))) / 4) + d - 32075;
-    } else {
-        jd = 367 * y - HijriDate.intPart((7 * (y + 5001 + HijriDate.intPart((m - 9) / 7))) / 4) + HijriDate.intPart((275 * m) / 9) + d + 1729777;
-    }
-    l = jd - 1948440 + 10632;
-    n = HijriDate.intPart((l - 1) / 10631);
-    l = l - 10631 * n + 354;
-    j = (HijriDate.intPart((10985 - l) / 5316)) * (HijriDate.intPart((50 * l) / 17719)) + (HijriDate.intPart(l / 5670)) * (HijriDate.intPart((43 * l) / 15238));
-    l = l - (HijriDate.intPart((30 - j) / 15)) * (HijriDate.intPart((17719 * j) / 50)) - (HijriDate.intPart(j / 16)) * (HijriDate.intPart((15238 * j) / 43)) + 29;
-    m = HijriDate.intPart((24 * l) / 709);
-    d = l - HijriDate.intPart((709 * m) / 24);
-    y = 30 * n + j - 30;
-
-    return {year: y, month: m, day: d};
+    [y, m, d] = julianDate_to_ghamari(miladi_to_julianDate(parseInt(y), parseInt(m), parseInt(d)));
+    return { year: y, month: m, day: d };
 };
 
 HijriDate.fromHijri = function (y, m, d) {
-    y = parseInt(y);
-    m = parseInt(m);
-    d = parseInt(d);
-
-    let i, j, jd, k, l, n;
-    jd = HijriDate.intPart((11 * y + 3) / 30) + 354 * y + 30 * m - HijriDate.intPart((m - 1) / 2) + d + 1948440 - 385;
-    if (jd > 2299160) {
-        l = jd + 68569;
-        n = HijriDate.intPart((4 * l) / 146097);
-        l -= HijriDate.intPart((146097 * n + 3) / 4);
-        i = HijriDate.intPart((4000 * (l + 1)) / 1461001);
-        l = l - HijriDate.intPart((1461 * i) / 4) + 31;
-        j = HijriDate.intPart((80 * l) / 2447);
-        d = l - HijriDate.intPart((2447 * j) / 80);
-        l = HijriDate.intPart(j / 11);
-        m = j + 2 - 12 * l;
-        y = 100 * (n - 49) + i + l;
-    } else {
-        j = jd + 1402;
-        k = HijriDate.intPart((j - 1) / 1461);
-        l = j - 1461 * k;
-        n = HijriDate.intPart((l - 1) / 365) - HijriDate.intPart(l / 1461);
-        i = l - 365 * n + 30;
-        j = HijriDate.intPart((80 * i) / 2447);
-        d = i - HijriDate.intPart((2447 * j) / 80);
-        i = HijriDate.intPart(j / 11);
-        m = j + 2 - 12 * i;
-        y = 4 * k + n + i - 4716;
-    }
-
-    return {year: y, month: m, day: d};
+    [y, m, d] = julianDate_to_miladi(ghamari_to_julianDate(parseInt(y), parseInt(m), parseInt(d)));
+    return { year: y, month: m, day: d };
 };
+
+
+// Private Function
+function ghamari_to_julianDate_0(iy, im, id) {
+    return (id + Math.ceil(29.5 * (im - 1)) + (iy - 1) * 354 + Math.floor((3 + (11 * iy)) / 30) + 1948439.5) - 1;
+}
+
+// Private Function
+function julianDate_to_ghamari_0(julianDate) {
+    var iy, im, id;
+    julianDate = Math.floor(julianDate) + 0.5;
+    iy = Math.floor(((30 * (julianDate - 1948439.5)) + 10646) / 10631);
+    im = Math.min(12, Math.ceil((julianDate - (29 + this.ghamari_to_julianDate_0(iy, 1, 1))) / 29.5) + 1);
+    id = (julianDate - this.ghamari_to_julianDate_0(iy, im, 1)) + 1;
+    return [iy, im, id];
+}
+
+function julianDate_to_miladi(julianDate) {
+    var sal_a, gy, gm, gd, days;
+    days = -parseInt(1721059.5 - julianDate);
+    gy = 400 * (parseInt(days / 146097));
+    days %= 146097;
+    if (days > 36524) {
+        gy += 100 * (parseInt(--days / 36524));
+        days %= 36524;
+        if (days >= 365) days++;
+    }
+    gy += 4 * (parseInt(days / 1461));
+    days %= 1461;
+    if (days > 365) {
+        gy += parseInt((days - 1) / 365);
+        days = (days - 1) % 365;
+    }
+    gd = days + 1;
+    sal_a = [0, 31, ((gy % 4 === 0 && gy % 100 !== 0) || (gy % 400 === 0)) ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    for (gm = 0; gm < 13, gd > sal_a[gm]; gm++) {
+        gd -= sal_a[gm];
+    }
+    return [gy, gm, gd];
+}
+
+function miladi_to_julianDate(gy, gm, gd) {
+    var g_d_m, gy2, julianDate;
+    g_d_m = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
+    gy2 = (gm > 2) ? (gy + 1) : gy;
+    julianDate = 1721059 + (365 * gy) + (parseInt((gy2 + 3) / 4)) - (parseInt((gy2 + 99) / 100)) + (parseInt((gy2 + 399) / 400)) + gd + g_d_m[gm - 1];
+    /* 1721059 = miladi_to_julianDate(0, 1, 1) - 1 */
+    return julianDate - 0.5;
+}
+
+// Private
+// https://github.com/ilius/starcal/blob/master/scal3/cal_types/hijri-monthes.json
+const ghamariMonths = {
+    startYear: 1427,/* =dim:firstYear */
+    startJd: 2453766.5,/* =ghamari_to_julianDate_0(startYear,1,1) */
+
+    endYear: 1442,/* =dim:lastYear */
+    endJd: 2459435.5,/* =ghamari_to_julianDate_0(endYear+1,1,1)-1 */
+
+    dim: {
+        1427: [355, 30, 29, 29, 30, 29, 30, 30, 30, 30, 29, 29, 30],
+        1428: [354, 29, 30, 29, 29, 29, 30, 30, 29, 30, 30, 30, 29],
+        1429: [354, 30, 29, 30, 29, 29, 29, 30, 30, 29, 30, 30, 29],
+        1430: [354, 30, 30, 29, 29, 30, 29, 30, 29, 29, 30, 30, 29],
+        1431: [354, 30, 30, 29, 30, 29, 30, 29, 30, 29, 29, 30, 29],
+        1432: [355, 30, 30, 29, 30, 30, 30, 29, 29, 30, 29, 30, 29],
+        1433: [355, 29, 30, 29, 30, 30, 30, 29, 30, 29, 30, 29, 30],
+        1434: [354, 29, 29, 30, 29, 30, 30, 29, 30, 30, 29, 30, 29],
+        1435: [355, 29, 30, 29, 30, 29, 30, 29, 30, 30, 30, 29, 30],
+        1436: [354, 29, 30, 29, 29, 30, 29, 30, 29, 30, 29, 30, 30],
+        1437: [354, 29, 30, 30, 29, 30, 29, 29, 30, 29, 29, 30, 30],
+        1438: [354, 29, 30, 30, 30, 29, 30, 29, 29, 30, 29, 29, 30],
+        1439: [354, 29, 30, 30, 30, 30, 29, 30, 29, 29, 30, 29, 29],
+        1440: [355, 30, 29, 30, 30, 30, 29, 30, 30, 29, 29, 30, 29],
+        1441: [355, 29, 30, 29, 30, 30, 29, 30, 30, 29, 30, 29, 30],
+        1442: [354/*|355*/, 29, 29, 30, 29, 30, 29, 30, 30, 30, 29, 30, 29/*|30 :خنثی‌سازی اختلاف مجموع کل*/]
+        /*
+            endJd - ghamari_to_julianDate_0(endYear,12,29)
+        */
+    }
+};
+
+function julianDate_to_ghamari(julianDate) {
+    if (julianDate < ghamariMonths.startJd || julianDate > ghamariMonths.endJd) {
+        return this.julianDate_to_ghamari_0(julianDate);
+    } else {
+        let iy, im;
+        let id = julianDate - ghamariMonths.startJd + 1;
+        for (iy in ghamariMonths.dim) {
+            if (id > ghamariMonths.dim[iy][0]) {
+                id -= ghamariMonths.dim[iy][0];
+            } else {
+                for (im = 1; im < 13, id > ghamariMonths.dim[iy][im]; im++) {
+                    id -= ghamariMonths.dim[iy][im];
+                }
+                break;
+            }
+        }
+        return [iy, im, id];
+    }
+}
+
+function ghamari_to_julianDate(iy, im, id) {
+    if (iy < ghamariMonths.startYear || iy > ghamariMonths.endYear) {
+        return this.ghamari_to_julianDate_0(iy, im, id);
+    } else {
+        let julianDate = ghamariMonths.startJd - 1 + id;
+        for (let y in ghamariMonths.dim) {
+            if (y < iy) {
+                julianDate += ghamariMonths.dim[y][0];
+            } else {
+                for (let m = 1; m < im; m++)julianDate += ghamariMonths.dim[iy][m];
+                break;
+            }
+        }
+        return julianDate;
+    }
+}
+

--- a/PersianCalendar@oxygenws.com/PersianDate.js
+++ b/PersianCalendar@oxygenws.com/PersianDate.js
@@ -1,104 +1,92 @@
+
+
 /*
- * Based on a code from http://farhadi.ir
+ * Edit by: jdf.scr.ir
  */
 
 var PersianDate = {
-    g_days_in_month: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
-    p_days_in_month: [31, 31, 31, 31, 31, 31, 30, 30, 30, 30, 30, 29],
+    // g_days_in_month: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+    // p_days_in_month: [31, 31, 31, 31, 31, 31, 30, 30, 30, 30, 30, 29],
     p_month_names: ['فروردین', 'اردیبهشت', 'خرداد', 'تیر', 'مرداد', 'شهریور', 'مهر', 'آبان', 'آذر', 'دی', 'بهمن', 'اسفند']
 };
 
-PersianDate.persianToGregorian = function (py, pm, pd) {
-    py = parseInt(py) - 979;
-    pm = parseInt(pm) - 1;
-    pd = parseInt(pd) - 1;
-
-    let p_day_no = 365 * py + parseInt(py / 33) * 8 + parseInt((py % 33 + 3) / 4);
-    for (let i = 0; i < pm; i++) {
-        p_day_no += PersianDate.p_days_in_month[i];
-    }
-
-    p_day_no += pd;
-
-    let g_day_no = p_day_no + 79;
-
-    let gy = 1600 + 400 * parseInt(g_day_no / 146097);
-    /* 146097 = 365*400 + 400/4 - 400/100 + 400/400 */
-    g_day_no %= 146097;
-
-    let leap = true;
-    /* 36525 = 365*100 + 100/4 */
-    if (g_day_no >= 36525) {
-        g_day_no--;
-        gy += 100 * parseInt(g_day_no / 36524);
-        /* 36524 = 365*100 + 100/4 - 100/100 */
-        g_day_no %= 36524;
-
-        if (g_day_no >= 365) {
-            g_day_no++;
-        } else {
-            leap = false;
-        }
-    }
-
-    gy += 4 * parseInt(g_day_no / 1461);
-    /* 1461 = 365*4 + 4/4 */
-    g_day_no %= 1461;
-
-    if (g_day_no >= 366) {
-        leap = false;
-
-        g_day_no--;
-        gy += parseInt(g_day_no / 365);
-        g_day_no %= 365;
-    }
-
-    let i = 0;
-    for (; g_day_no >= PersianDate.g_days_in_month[i] + (i === 1 && leap); i++) {
-        g_day_no -= PersianDate.g_days_in_month[i] + (i === 1 && leap);
-    }
-
-    return {year: gy, month: i + 1, day: g_day_no + 1};
-};
-
 PersianDate.checkDate = function (py, pm, pd) {
-    return !(py < 0 || py > 32767 || pm < 1 || pm > 12 || pd < 1 || pd >
-    (PersianDate.p_days_in_month[pm - 1] + (pm === 12 && !((py - 979) % 33 % 4))));
+    return !(py < 0 || py > 32767 || pm < 1 || pm > 12 || pd < 1 || pd > PersianDate.pDaysInMonth(py, pm));
 };
+
+PersianDate.isKabiseh = function (py, outType = 'bool') {
+    types = {
+        'int': [0, 1],
+        'bool': [false, true],
+        'yearDays': [365, 366],
+        'esfandDays': [29, 30],
+        'farsi': ["کبیسه نیست", "کبیسه است"]
+    }
+    return ((((year + 12) % 33) % 4) === 1) ? types[outType][1] : types[outType][0];
+};
+
+PersianDate.pDaysInMonth = function (py, pm) {
+    return ((pm < 7) ? 31 : ((pm < 12) ? 30 : PersianDate.isKabiseh(py, 'esfandDays')));
+};
+
+
+/**  Gregorian & Jalali (Hijri_Shamsi,Solar) Date Converter Functions
+Author: JDF.SCR.IR =>> Download Full Version :  http://jdf.scr.ir/jdf
+License: GNU/LGPL _ Open Source & Free :: Version: 2.80 : [2020=1399]
+---------------------------------------------------------------------
+355746=361590-5844 & 361590=(30*33*365)+(30*8) & 5844=(16*365)+(16/4)
+355666=355746-79-1 & 355668=355746-79+1 &  1595=605+990 &  605=621-16
+990=30*33 & 12053=(365*33)+(32/4) & 36524=(365*100)+(100/4)-(100/100)
+1461=(365*4)+(4/4) & 146097=(365*400)+(400/4)-(400/100)+(400/400)  */
 
 PersianDate.gregorianToPersian = function (gy, gm, gd) {
-    gy = parseInt(gy) - 1600;
-    gm = parseInt(gm) - 1;
-    gd = parseInt(gd) - 1;
-
-    let g_day_no = 365 * gy + parseInt((gy + 3) / 4) - parseInt((gy + 99) / 100) + parseInt((gy + 399) / 400);
-
-    for (let i = 0; i < gm; ++i) {
-        g_day_no += PersianDate.g_days_in_month[i];
+    [gy, gm, gd] = [parseInt(gy), parseInt(gm), parseInt(gd)];
+    var g_d_m, jy, jm, jd, gy2, days;
+    g_d_m = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
+    gy2 = (gm > 2) ? (gy + 1) : gy;
+    days = 355666 + (365 * gy) + parseInt((gy2 + 3) / 4) - parseInt((gy2 + 99) / 100) + parseInt((gy2 + 399) / 400) + gd + g_d_m[gm - 1];
+    jy = -1595 + (33 * parseInt(days / 12053));
+    days %= 12053;
+    jy += 4 * parseInt(days / 1461);
+    days %= 1461;
+    if (days > 365) {
+        jy += parseInt((days - 1) / 365);
+        days = (days - 1) % 365;
     }
-    /* leap and after Feb */
-    if (gm > 1 && ((gy % 4 === 0 && gy % 100 !== 0) || (gy % 400 === 0))) {
-        ++g_day_no;
+    let day_in_year = days + 1;//extra
+    if (days < 186) {
+        jm = 1 + parseInt(days / 31);
+        jd = 1 + (days % 31);
+    } else {
+        jm = 7 + parseInt((days - 186) / 30);
+        jd = 1 + ((days - 186) % 30);
     }
-    g_day_no += gd;
+    // return [jy, jm, jd];
+    return { year: jy, month: jm, day: jd, yearDays: day_in_year };
+}
 
-    let p_day_no = g_day_no - 79;
-    let p_np = parseInt(p_day_no / 12053);
-    p_day_no %= 12053;
-
-    let py = 979 + 33 * p_np + 4 * parseInt(p_day_no / 1461);
-    p_day_no %= 1461;
-
-    if (p_day_no >= 366) {
-        py += parseInt((p_day_no - 1) / 365);
-        p_day_no = (p_day_no - 1) % 365;
+PersianDate.persianToGregorian = function (jy, jm, jd) {
+    [jy, jm, jd] = [parseInt(jy), parseInt(jm), parseInt(jd)];
+    var sal_a, gy, gm, gd, days;
+    jy += 1595;
+    days = -355668 + (365 * jy) + (parseInt(jy / 33) * 8) + parseInt(((jy % 33) + 3) / 4) + jd + ((jm < 7) ? (jm - 1) * 31 : ((jm - 7) * 30) + 186);
+    gy = 400 * parseInt(days / 146097);
+    days %= 146097;
+    if (days > 36524) {
+        gy += 100 * parseInt(--days / 36524);
+        days %= 36524;
+        if (days >= 365) days++;
     }
-
-    let day_in_year = p_day_no + 1;
-    let i = 0;
-    for (; i < 11 && p_day_no >= PersianDate.p_days_in_month[i]; ++i) {
-        p_day_no -= PersianDate.p_days_in_month[i];
+    gy += 4 * parseInt(days / 1461);
+    days %= 1461;
+    if (days > 365) {
+        gy += parseInt((days - 1) / 365);
+        days = (days - 1) % 365;
     }
-
-    return {year: py, month: i + 1, day: p_day_no + 1, yearDays: day_in_year};
-};
+    gd = days + 1;
+    let day_in_year = gd;//extra
+    sal_a = [0, 31, ((gy % 4 === 0 && gy % 100 !== 0) || (gy % 400 === 0)) ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    for (gm = 0; gm < 13 && gd > sal_a[gm]; gm++) gd -= sal_a[gm];
+    // return [gy, gm, gd];
+    return { year: gy, month: gm, day: gd, yearDays: day_in_year };
+}

--- a/PersianCalendar@oxygenws.com/extension.js
+++ b/PersianCalendar@oxygenws.com/extension.js
@@ -47,7 +47,7 @@ const PersianCalendar = new Lang.Class({
             y_expand: true,
             y_align: Clutter.ActorAlign.CENTER,
         });
-        this.add_actor(this.label);
+        this.actor.add_actor(this.label);
 
         // some codes for coloring label
         if (Schema.get_boolean('custom-color')) {

--- a/PersianCalendar@oxygenws.com/metadata.json
+++ b/PersianCalendar@oxygenws.com/metadata.json
@@ -4,9 +4,17 @@
   "name": "Persian Calendar",
   "original-authors": "Omid Mottaghi Rad",
   "shell-version": [
+    "3.20",
+    "3.22",
+    "3.24",
+    "3.26",
+    "3.28",
+    "3.30",
+    "3.32",
+    "3.34",
     "3.36"
   ],
   "url": "https://github.com/omid/Persian-Calendar-for-Gnome-Shell",
   "uuid": "PersianCalendar@oxygenws.com",
-  "version": 70
+  "version": 71
 }


### PR DESCRIPTION
الگوریتم تاریخ هجری **قمری** که برخی اوقات ۱ روز اختلاف داشت، بهبود یافت.

الگوریتم تاریخ هجری **شمسی** (جلالی) بهبود یافت.

پشتیبانی از نسخه‌های قبلی گنوم، افزایش یافت و اکنون از نسخه‌ی **3.20** به بعد، سازگاری دارند.
آزمایش شد:
Fedora 24 - Gnome 3.20
Ubuntu 18 - Gnome 3.28
Debian 10 - Gnome 3.30
Ubuntu 20 - Gnome 3.36

عدم سازگاری به‌خاطر سطر 50 فایل 
extension.js
 بود که با تغییرات کنونی، هم با نسخه‌های قدیمی و هم با نسخه‌های جدید، سازگاری دارد.