### PR TITLE
fix: add calendar icon to notifications to prevent crashes

### DIFF
--- a/PersianCalendar@oxygenws.com/extension.js
+++ b/PersianCalendar@oxygenws.com/extension.js
@@ -251,7 +251,7 @@ const PersianCalendar = GObject.registerClass(
                 'persian',
             ));
             if (!skip_notification) {
-                this.notify(_date, events[0]);
+                this.notify(_date, events[0], 'x-office-calendar-symbolic');
             }
 
             return true;

--- a/PersianCalendar@oxygenws.com/metadata.json
+++ b/PersianCalendar@oxygenws.com/metadata.json
@@ -11,5 +11,5 @@
   ],
   "url": "https://github.com/omid/Persian-Calendar-for-Gnome-Shell",
   "uuid": "PersianCalendar@oxygenws.com",
-  "version": 117
+  "version": 118
 }


### PR DESCRIPTION
It looks like that `MessageTray.Notification` always need an icon in gnome 48, so I've added `x-office-calendar-symbolic` as default notification icon so we don't get a crash with this message:
```
Error: Invalid value 'undefined' for property icon-name in object initializer.
```