### PR TITLE
fix startup crash

### DIFF
--- a/PersianCalendar@oxygenws.com/extension.js
+++ b/PersianCalendar@oxygenws.com/extension.js
@@ -514,7 +514,7 @@ const PersianCalendar = GObject.registerClass(
             const notification = new MessageTray.Notification({
                 source,
                 title,
-                iconName: iconName ? iconName : null,
+                iconName: iconName ? iconName : 'x-office-calendar-symbolic',
                 isTransient: true,
                 body: body ? body : null,
             });


### PR DESCRIPTION
gnome crashes as `MessageTray.Notification` needs an icon name instead of null