### PR TITLE
fix: add missing push to _hooks array and fix localization

### DIFF
--- a/PersianCalendar@oxygenws.com/extension.js
+++ b/PersianCalendar@oxygenws.com/extension.js
@@ -127,7 +127,7 @@ const PersianCalendar = GObject.registerClass(
             // remember to remove it within the disable function
             // Main.sessionMode.connect('updated', () => this._genActionButtonsPart());
 
-            this._hooks([this.menu, this.menu.connect('open-state-changed', isOpen => {
+            this._hooks.push([this.menu, this.menu.connect('open-state-changed', isOpen => {
                 if (isOpen) {
                     let now = new Date();
                     now = PersianDate.fromGregorian(now.getFullYear(), now.getMonth() + 1, now.getDate());
@@ -331,7 +331,7 @@ const PersianCalendar = GObject.registerClass(
                 x_expand: true,
                 style_class: 'pcalendar-converter-entry',
             });
-            this._hooks([this.converterYear.clutter_text, this.converterYear.clutter_text.connect('text-changed', this._onModifyConverter.bind(this))]);
+            this._hooks.push([this.converterYear.clutter_text, this.converterYear.clutter_text.connect('text-changed', this._onModifyConverter.bind(this))]);
 
             this.converterMonth = new St.Entry({
                 name: 'month',
@@ -340,7 +340,7 @@ const PersianCalendar = GObject.registerClass(
                 x_expand: true,
                 style_class: 'pcalendar-converter-entry',
             });
-            this._hooks([this.converterMonth.clutter_text, this.converterMonth.clutter_text.connect('text-changed', this._onModifyConverter.bind(this))]);
+            this._hooks.push([this.converterMonth.clutter_text, this.converterMonth.clutter_text.connect('text-changed', this._onModifyConverter.bind(this))]);
 
             this.converterDay = new St.Entry({
                 name: 'day',
@@ -360,7 +360,7 @@ const PersianCalendar = GObject.registerClass(
                 converterHbox.add_child(this.converterDay);
             }
 
-            this._hooks([this.converterDay.clutter_text, this.converterDay.clutter_text.connect('text-changed', this._onModifyConverter.bind(this))]);
+            this._hooks.push([this.converterDay.clutter_text, this.converterDay.clutter_text.connect('text-changed', this._onModifyConverter.bind(this))]);
 
             this.converterVbox.add_child(converterHbox);
 

--- a/PersianCalendar@oxygenws.com/metadata.json
+++ b/PersianCalendar@oxygenws.com/metadata.json
@@ -6,5 +6,5 @@
   "shell-version": ["48", "49", "50"],
   "url": "https://github.com/omid/Persian-Calendar-for-Gnome-Shell",
   "uuid": "PersianCalendar@oxygenws.com",
-  "version": 127
+  "version": 128
 }

--- a/PersianCalendar@oxygenws.com/utils/gettext.js
+++ b/PersianCalendar@oxygenws.com/utils/gettext.js
@@ -40,7 +40,7 @@ export class GetText {
         let lang = settings.get_string('language');
         let localeJsonFile = Gio.File.new_for_path(`${path}/locale/${lang}.json`);
         try {
-            let [_, localeJson] = localeJsonFile.load_contents_async(null);
+            let [_, localeJson] = localeJsonFile.load_contents(null);
             let decoder = new TextDecoder('utf-8');
             this.locale = JSON.parse(decoder.decode(localeJson));
         } catch {


### PR DESCRIPTION
Fixes issues with 127 that causes extension to crash

- Added missing `.push` calls (extension crashing with `_hooks` is not a function)
- Switching to async locale caused failure in pulling the translation, reverted
- Bumped version to 128